### PR TITLE
Candidate Bullets

### DIFF
--- a/Candidate/creature_scene.gd
+++ b/Candidate/creature_scene.gd
@@ -1,5 +1,6 @@
 extends CharacterBody2D
 
+const bullet_scene = preload("res://fight_scenes/bullets/basic_bullet.tscn")
 var current_form
 var speed = 300
 var health = 5
@@ -20,3 +21,12 @@ func speed_up():
 func hit():
 	health = health - 1
 	print("Hit!")
+
+func _unhandled_input(_event):
+	if Input.is_action_just_pressed("interact") and get_tree().current_scene.name == "first_fight":
+		var bullet = bullet_scene.instantiate()
+		get_tree().root.add_child(bullet)
+		bullet.position = position + Vector2(40.0, 0.0) # Sets position 
+		bullet.rotation = rotation
+		bullet.apply_scale(Vector2(2, 2)) # Sets scale of bullet, <1,1> is original size
+		return

--- a/fight_scenes/first_fight.tscn
+++ b/fight_scenes/first_fight.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://bumdxy42h4pem"]
 
 [ext_resource type="PackedScene" uid="uid://itd28xc30rm3" path="res://fight_scenes/battle_scenes.tscn" id="1_spoch"]
-[ext_resource type="PackedScene" uid="uid://q1jsmk1qap2h" path="res://creature_scene.tscn" id="2_g8hdm"]
-[ext_resource type="PackedScene" uid="uid://c0krkt7fd8n83" path="res://first_enemy.tscn" id="3_t0ja6"]
+[ext_resource type="PackedScene" uid="uid://q1jsmk1qap2h" path="res://Candidate/creature_scene.tscn" id="2_g8hdm"]
+[ext_resource type="PackedScene" uid="uid://c0krkt7fd8n83" path="res://fight_scenes/enemies/first_enemy.tscn" id="3_t0ja6"]
 
 [node name="first_fight" instance=ExtResource("1_spoch")]
 

--- a/pitstop_scenes/player_scene.gd
+++ b/pitstop_scenes/player_scene.gd
@@ -19,7 +19,6 @@ func _unhandled_input(_event):
 		if actionables.size() > 0:
 			actionables[0].action()
 			return
-		
 
 
 

--- a/pitstop_scenes/player_scene.tscn
+++ b/pitstop_scenes/player_scene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://bcnxpksao7wux"]
 
 [ext_resource type="Script" path="res://pitstop_scenes/player_scene.gd" id="1_mwxqu"]
-[ext_resource type="Texture2D" uid="uid://cjgncx8rbp5lq" path="res://Sprites/player_sprites/placeholder player.png" id="2_2t7kq"]
+[ext_resource type="Texture2D" uid="uid://cjgncx8rbp5lq" path="res://Sprites/player_sprite/placeholder player.png" id="2_2t7kq"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_kt11b"]
 size = Vector2(32, 67)


### PR DESCRIPTION
If in first_fight scene, you can now shoot a bullet directly horizontal to the player using the interact button.
Right now, there is a hard-coded offset of the bullet's position at instantiation so that it does not collide with the candidate upon use. I can and will fix this to be dependent on the hitbox of the candidate once we finalize hitboxes and I figure out how to do that.
Current bullet asset being used is the one the boss uses